### PR TITLE
DDCE-6952 -Updated Bootstrap, MangoDB and SBT plugin versions

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,8 +1,8 @@
 import sbt.*
 
 object AppDependencies {
-  val bootstrapVersion = "9.13.0"
-  val mongoVersion = "2.6.0"
+  val bootstrapVersion = "9.18.0"
+  val mongoVersion = "2.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                     % mongoVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework"    % "sbt-plugin"            % "3.0.7")
+addSbtPlugin("org.playframework"    % "sbt-plugin"            % "3.0.8")
 addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("org.scoverage"        % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("io.github.irundaia"   % "sbt-sassify"           % "1.5.2")


### PR DESCRIPTION
DDCE-6952 -Updated BootstrapVersion, MongoVersion & sbt-plugin to 9.18.0 , 2.7.0 & 3.0.8 respectively for maintain-trust-asset-frontend. 
<img width="944" height="548" alt="DDCE-6952 - maintain-trust-asset-frontend- Execution Result" src="https://github.com/user-attachments/assets/48ec50bc-b70c-4086-abbb-940357037bb3" />
